### PR TITLE
refactor(typegen): path parameters required in output

### DIFF
--- a/packages/typegen/package-lock.json
+++ b/packages/typegen/package-lock.json
@@ -14,6 +14,7 @@
         "axios": ">=0.25.0",
         "indent-string": "^4.0.0",
         "lodash": "^4.17.21",
+        "openapi-client-axios": "^7.4.0",
         "openapi-types": "^12.1.0",
         "yargs": "^17.3.0"
       },
@@ -1523,6 +1524,11 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/bath-es5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bath-es5/-/bath-es5-3.0.3.tgz",
+      "integrity": "sha512-PdCioDToH3t84lP40kUFCKWCOCH389Dl1kbC8FGoqOwamxsmqxxnJSXdkTOsPoNHXjem4+sJ+bbNoQm5zeCqxg=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -1786,6 +1792,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dereference-json-schema": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dereference-json-schema/-/dereference-json-schema-0.2.1.tgz",
+      "integrity": "sha512-uzJsrg225owJyRQ8FNTPHIuBOdSzIZlHhss9u6W8mp7jJldHqGuLv9cULagP/E26QVJDnjtG8U7Dw139mM1ydA=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3472,6 +3483,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-client-axios": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/openapi-client-axios/-/openapi-client-axios-7.4.0.tgz",
+      "integrity": "sha512-qD7LjzKWfs/Rp+9NfFrtzpxVzlJHqau3O0W/wQ8oEzyvhokdJKkq08rzINcElBVuz+KZO+jUOC0zJz8r+IRPyQ==",
+      "dependencies": {
+        "bath-es5": "^3.0.3",
+        "dereference-json-schema": "^0.2.1",
+        "openapi-types": "^12.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/anttiviljami"
+      },
+      "peerDependencies": {
+        "axios": ">=0.25.0",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/openapi-types": {

--- a/packages/typegen/package-lock.json
+++ b/packages/typegen/package-lock.json
@@ -14,7 +14,6 @@
         "axios": ">=0.25.0",
         "indent-string": "^4.0.0",
         "lodash": "^4.17.21",
-        "openapi-client-axios": "^7.4.0",
         "openapi-types": "^12.1.0",
         "yargs": "^17.3.0"
       },
@@ -1524,11 +1523,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/bath-es5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bath-es5/-/bath-es5-3.0.3.tgz",
-      "integrity": "sha512-PdCioDToH3t84lP40kUFCKWCOCH389Dl1kbC8FGoqOwamxsmqxxnJSXdkTOsPoNHXjem4+sJ+bbNoQm5zeCqxg=="
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
@@ -1792,11 +1786,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/dereference-json-schema": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dereference-json-schema/-/dereference-json-schema-0.2.1.tgz",
-      "integrity": "sha512-uzJsrg225owJyRQ8FNTPHIuBOdSzIZlHhss9u6W8mp7jJldHqGuLv9cULagP/E26QVJDnjtG8U7Dw139mM1ydA=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3483,23 +3472,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-client-axios": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/openapi-client-axios/-/openapi-client-axios-7.4.0.tgz",
-      "integrity": "sha512-qD7LjzKWfs/Rp+9NfFrtzpxVzlJHqau3O0W/wQ8oEzyvhokdJKkq08rzINcElBVuz+KZO+jUOC0zJz8r+IRPyQ==",
-      "dependencies": {
-        "bath-es5": "^3.0.3",
-        "dereference-json-schema": "^0.2.1",
-        "openapi-types": "^12.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/anttiviljami"
-      },
-      "peerDependencies": {
-        "axios": ">=0.25.0",
-        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/openapi-types": {

--- a/packages/typegen/src/typegen.test.ts
+++ b/packages/typegen/src/typegen.test.ts
@@ -11,6 +11,7 @@ describe('typegen', () => {
   beforeAll(async () => {
     const types = await generateTypesForDocument(examplePetAPIYAML, {
       transformOperationName: (operationId: string) => operationId,
+      disableOptionalPathParameters: true,
     });
     imports = types[0];
     schemaTypes = types[1];
@@ -36,6 +37,15 @@ describe('typegen', () => {
       expect(operationTypings).toMatch('getPetOwner');
       expect(operationTypings).toMatch('getPetsMeta');
       expect(operationTypings).toMatch('getPetsRelative');
+    });
+
+    test('types parameters', () => {
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.GetPetById.PathParameters>`);
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.ReplacePetById.PathParameters>`);
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.UpdatePetById.PathParameters>`);
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.DeletePetById.PathParameters>`);
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.GetOwnerByPetId.PathParameters>`);
+      expect(operationTypings).toMatch(`parameters: Parameters<Paths.GetPetOwner.PathParameters>`);
     });
 
     test('types responses', () => {

--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -131,7 +131,7 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
   let parametersArg = `parameters?: Parameters<${parametersType}> | null`;
 
   // All path parameters are required
-  if (_.isEmpty(pathParameterTypePaths)) {
+  if (!_.isEmpty(pathParameterTypePaths)) {
     parametersArg = `parameters: Parameters<${parametersType}>`;
   }
 


### PR DESCRIPTION
This PR omits the optional on parameters if path parameters are used. This can be enabled using the CLI options disableOptionalPathParameters.

The reason for this PR is that path parameters are always required and it doesn't make sense that they should be optional.