### PR TITLE
fix(typegen): fix disableOptionalPathParameters

### DIFF
--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -38,7 +38,7 @@ export async function main() {
       type: 'string',
     })
     .option('disableOptionalPathParameters', {
-      type: 'string',
+      type: 'boolean',
       description: 'Force all path parameters to be required',
       default: true,
     })


### PR DESCRIPTION
The option is forced to `true` from [this commit](https://github.com/openapistack/openapi-client-axios/commit/e9d85e5060bcab9a486584e1144abd076fea4b58), but the argument is not typed correctly, which make the parameter unusuable